### PR TITLE
Add command line arguments to allow parsing of assembly files

### DIFF
--- a/DocNet.Console/DocNet.Console.csproj
+++ b/DocNet.Console/DocNet.Console.csproj
@@ -25,6 +25,7 @@
     <CodeAnalysisRuleSet>..\.global\DocNet.ruleset</CodeAnalysisRuleSet>
     <NoWarn>
     </NoWarn>
+    <DocumentationFile>bin\Debug\DocNet.Console.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/DocNet.Console/Program.cs
+++ b/DocNet.Console/Program.cs
@@ -54,10 +54,21 @@ namespace DocNet.Console
                 return (int) DocNetStatus.Success;
             }
 
-            programArgs.InputPaths = RemoveInitialWhitespacefromPaths(programArgs.InputPaths);
+            if(programArgs.InputSourcePaths != null)
+            {
+                programArgs.InputSourcePaths = RemoveInitialWhitespacefromPaths(programArgs.InputSourcePaths);
+            }
+
+            if (programArgs.InputAssemblyPaths != null)
+            {
+                programArgs.InputAssemblyPaths = RemoveInitialWhitespacefromPaths(programArgs.InputAssemblyPaths);
+            }
                 
             if (programArgs.DirectoryModeSpecified)
-                programArgs.InputPaths = GetCsFileListFromDirectoryList(programArgs.InputPaths, programArgs.UseRecursiveSearch);
+                if (programArgs.InputSourcePaths != null)
+                {
+                    programArgs.InputSourcePaths = GetCsFileListFromDirectoryList(programArgs.InputSourcePaths, programArgs.UseRecursiveSearch);
+                }
 
             var program = new Program();
             int status = (int)program.Run(programArgs);
@@ -88,6 +99,7 @@ namespace DocNet.Console
                 SolutionParser = new OnionSolutionParserWrapper(projectParser),
                 ProjectParser = projectParser,
                 CsSourceParser = new CsSourceParser(),
+                CsAssemblyParser = new CsAssemblyParser(),
                 DocumentationGenerator = new HtmlDocumentationGenerator(exportedFileList), 
                 RootDirectoryName = ConfigurationManager.AppSettings["RootDirectoryName"] ?? DefaultRootDirectoryName,
             };
@@ -109,14 +121,24 @@ namespace DocNet.Console
             try
             {
                 string currentDirectoryPath = Directory.GetCurrentDirectory();
-                var documentationSettings = new DocumentationSettings
+                var outputDirectoryPath = MakePathAbsolute(currentDirectoryPath, args.OutputDirectory);
+                var outputMode = GetOutputMode(args);
+
+                if (args.InputSourcePaths != null)
                 {
-                    InputFilePaths = args.InputPaths.Select(p => MakePathAbsolute(currentDirectoryPath, p)),
-                    OutputDirectoryPath = MakePathAbsolute(currentDirectoryPath, args.OutputDirectory),
-                    OutputMode = GetOutputMode(args)
-                };
-  
-                return _controller.Execute(documentationSettings);
+                    var inputFilePaths = args.InputSourcePaths.Select(p => MakePathAbsolute(currentDirectoryPath, p));
+                    return _controller.ExecuteSourceParser(inputFilePaths, outputDirectoryPath, outputMode);
+                }
+                else if (args.InputAssemblyPaths != null)
+                {
+                    var inputFilePairs = args.InputAssemblyPaths.Select(p => MakeAbsoluteAssemblyXmlPairs(currentDirectoryPath, p));
+                    return _controller.ExecuteAssemblyParser(inputFilePairs, outputDirectoryPath, outputMode);
+                }
+                else
+                {
+                    Log.Error("No input files specified. Please specify source files using -s or assembly files using -a.");
+                    return DocNetStatus.InvalidProgramArguments;
+                }
             }
             catch (Exception ex)
             {
@@ -155,6 +177,21 @@ namespace DocNet.Console
                 return Path.GetFullPath(Path.Combine(currentDirectoryPath, path));
             }
             return path;
+        }
+
+        private static AssemblyXmlPair MakeAbsoluteAssemblyXmlPairs(string currentDirectoryPath, string path)
+        {
+            if(String.IsNullOrWhiteSpace(path)) return null;
+            string[] pair = path.Split('=');
+            if(!Path.IsPathRooted(pair[0]))
+            {
+                pair[0] = Path.GetFullPath(Path.Combine(currentDirectoryPath, pair[0]));
+            }
+            if(!Path.IsPathRooted(pair[1]))
+            {
+                pair[1] = Path.GetFullPath(Path.Combine(currentDirectoryPath, pair[1]));
+            }
+            return new AssemblyXmlPair{ AssemblyFilePath = pair[0], XmlFilePath = pair[1] };
         }
 
         private static string GetHelpMessage(ProgramArguments args)

--- a/DocNet.Console/Program.cs
+++ b/DocNet.Console/Program.cs
@@ -131,7 +131,7 @@ namespace DocNet.Console
                 }
                 else if (args.InputAssemblyPaths != null)
                 {
-                    var inputFilePairs = args.InputAssemblyPaths.Select(p => MakeAbsoluteAssemblyXmlPairs(currentDirectoryPath, p));
+                    var inputFilePairs = args.InputAssemblyPaths.Select(p => MakeAssemblyXmlPair(currentDirectoryPath, p));
                     return _controller.ExecuteAssemblyParser(inputFilePairs, outputDirectoryPath, outputMode);
                 }
                 else
@@ -179,19 +179,20 @@ namespace DocNet.Console
             return path;
         }
 
-        private static AssemblyXmlPair MakeAbsoluteAssemblyXmlPairs(string currentDirectoryPath, string path)
+        private static AssemblyXmlPair MakeAssemblyXmlPair(string currentDirectoryPath, string path)
         {
             if(String.IsNullOrWhiteSpace(path)) return null;
-            string[] pair = path.Split('=');
-            if(!Path.IsPathRooted(pair[0]))
-            {
-                pair[0] = Path.GetFullPath(Path.Combine(currentDirectoryPath, pair[0]));
-            }
-            if(!Path.IsPathRooted(pair[1]))
-            {
-                pair[1] = Path.GetFullPath(Path.Combine(currentDirectoryPath, pair[1]));
-            }
-            return new AssemblyXmlPair{ AssemblyFilePath = pair[0], XmlFilePath = pair[1] };
+
+            AssemblyXmlPair pair = new AssemblyXmlPair();
+
+            string[] paths = path.Split('=');
+            string assemblyPath = MakePathAbsolute(currentDirectoryPath, paths[0]);
+            string xmlPath = MakePathAbsolute(currentDirectoryPath, paths[1]);
+
+            pair.AssemblyFilePath = assemblyPath;
+            pair.XmlFilePath = xmlPath;
+
+            return pair;
         }
 
         private static string GetHelpMessage(ProgramArguments args)

--- a/DocNet.Console/Program.cs
+++ b/DocNet.Console/Program.cs
@@ -27,7 +27,7 @@ namespace DocNet.Console
         /// The entry point into the DocNet command line tool.
         /// </summary>
         /// <param name="args">
-        ///     An array of program arguments. Seethe <see cref="ProgramArguments"/> class for more detailed
+        ///     An array of program arguments. See the <see cref="ProgramArguments"/> class for more detailed
         ///     information on expected program arguments.
         /// </param>
         /// <returns>A DocNet status code.</returns>
@@ -87,7 +87,7 @@ namespace DocNet.Console
             {
                 SolutionParser = new OnionSolutionParserWrapper(projectParser),
                 ProjectParser = projectParser,
-                CsParser = new CsTextParser(),
+                CsSourceParser = new CsSourceParser(),
                 DocumentationGenerator = new HtmlDocumentationGenerator(exportedFileList), 
                 RootDirectoryName = ConfigurationManager.AppSettings["RootDirectoryName"] ?? DefaultRootDirectoryName,
             };

--- a/DocNet.Console/ProgramArguments.cs
+++ b/DocNet.Console/ProgramArguments.cs
@@ -17,7 +17,7 @@ namespace DocNet.Console
         /// <summary>
         /// Indicates whether the '-a' or '--all' flags have been entered by the user.
         /// </summary>
-        [Option('a', "all", HelpText = "The program will document all C# elements, regardless of access modifier or whether or not the element has a documentation comment.", Required = false)]
+        [Option('A', "all", HelpText = "The program will document all C# elements, regardless of access modifier or whether or not the element has a documentation comment.", Required = false)]
         public bool DocumentAllElement { get; set; }
 
         /// <summary>
@@ -33,15 +33,21 @@ namespace DocNet.Console
         public bool UseRecursiveSearch { get; set; }
 
         /// <summary>
+        /// Contains the list of source input files specified by the user.
+        /// </summary>
+        [OptionList('s', "source", Separator = ',', HelpText = "Paths to program source input files or directories (mode dependent).", MutuallyExclusiveSet = "inputMode")]
+        public IList<string> InputSourcePaths { get; set; }
+
+        /// <summary>
+        /// Contains the list of assembly/xml input file pairs specified by the user.
+        /// </summary>
+        [OptionList('a', "assembly", Separator = ',', HelpText = "Paths to program assembly input files or directories (mode dependent).", MutuallyExclusiveSet = "inputMode")]
+        public IList<string> InputAssemblyPaths { get; set; }
+
+        /// <summary>
         /// Contains the output directory specified by the user.
         /// </summary>
         [Option('o', "output", HelpText = "The output directory where the program will store generated documentation.", Required = true)]
         public string OutputDirectory { get; set; }
-
-        /// <summary>
-        /// Contains the list of input files specified by the user.
-        /// </summary>
-        [OptionList('i', "input", Separator = ',', Required = true, HelpText = "Paths to program input files or directories (mode dependent).")]
-        public IList<string> InputPaths { get; set; }
     }
 }

--- a/DocNet.Core/AssemblyXmlPair.cs
+++ b/DocNet.Core/AssemblyXmlPair.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace DocNet.Core
+{
+    public class AssemblyXmlPair : IEquatable<AssemblyXmlPair>
+    {
+
+        public string AssemblyFilePath { get; set; }
+        public string XmlFilePath { get; set; }
+
+        public override int GetHashCode()
+        {
+            int hashCode = AssemblyFilePath != null ? AssemblyFilePath.GetHashCode() : 0;
+            hashCode = (hashCode * 397) ^ (XmlFilePath != null ? XmlFilePath.GetHashCode() : 0);
+            return hashCode;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AssemblyXmlPair);
+        }
+
+        public bool Equals(AssemblyXmlPair other)
+        {
+            if (other == null) return false;
+            if (this == other) return true;
+            return String.Equals(AssemblyFilePath, other.AssemblyFilePath) &&
+                String.Equals(XmlFilePath, other.XmlFilePath);
+        }
+
+    }
+}

--- a/DocNet.Core/AssemblyXmlPair.cs
+++ b/DocNet.Core/AssemblyXmlPair.cs
@@ -8,6 +8,8 @@ namespace DocNet.Core
         public string AssemblyFilePath { get; set; }
         public string XmlFilePath { get; set; }
 
+        #region Equality Members
+
         public override int GetHashCode()
         {
             int hashCode = AssemblyFilePath != null ? AssemblyFilePath.GetHashCode() : 0;
@@ -27,6 +29,8 @@ namespace DocNet.Core
             return String.Equals(AssemblyFilePath, other.AssemblyFilePath) &&
                 String.Equals(XmlFilePath, other.XmlFilePath);
         }
+
+        #endregion
 
     }
 }

--- a/DocNet.Core/ControllerConfiguration.cs
+++ b/DocNet.Core/ControllerConfiguration.cs
@@ -32,6 +32,11 @@ namespace DocNet.Core
         public ICsSourceParser CsSourceParser { get; set; }
 
         /// <summary>
+        /// The parser used to parse assembly (.dll) files.
+        /// </summary>
+        public ICsAssemblyParser CsAssemblyParser { get; set; }
+
+        /// <summary>
         /// The documentation generator used to output documentation.
         /// </summary>
         public IDocumentationGenerator DocumentationGenerator { get; set; }

--- a/DocNet.Core/ControllerConfiguration.cs
+++ b/DocNet.Core/ControllerConfiguration.cs
@@ -29,7 +29,7 @@ namespace DocNet.Core
         /// <summary>
         /// The parser used to parse C# (.cs) files.
         /// </summary>
-        public ICsParser CsParser { get; set; }
+        public ICsSourceParser CsSourceParser { get; set; }
 
         /// <summary>
         /// The documentation generator used to output documentation.
@@ -54,7 +54,7 @@ namespace DocNet.Core
                 throw new ConfigurationException("Solution parser is null.", DocNetStatus.InternalError);
             if(ProjectParser == null)
                 throw new ConfigurationException("Project parser is null.", DocNetStatus.InternalError);
-            if(CsParser == null)
+            if(CsSourceParser == null)
                 throw new ConfigurationException("C# parser is null.", DocNetStatus.InternalError);
             if(DocumentationGenerator == null)
                 throw new ConfigurationException("Documentation generator is null.", DocNetStatus.InternalError);

--- a/DocNet.Core/DocNet.Core.csproj
+++ b/DocNet.Core/DocNet.Core.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>DocNet.Core</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>e475a2c3</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>91a8b903</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -85,6 +85,7 @@
     <Compile Include="Exceptions\IllegalChildElementException.cs" />
     <Compile Include="Exceptions\InvalidFileTypeException.cs" />
     <Compile Include="Exceptions\NamingCollisionException.cs" />
+    <Compile Include="Models\Comments\Xml\XmlDocFileSchema.cs" />
     <Compile Include="Models\CSharp\ClassAndStructBase.cs" />
     <Compile Include="Models\CSharp\CsElement.cs" />
     <Compile Include="Models\CSharp\CsType.cs" />
@@ -185,8 +186,11 @@
     </Compile>
     <Compile Include="Output\IDocumentationGenerator.cs" />
     <Compile Include="OutputMode.cs" />
-    <Compile Include="Parsers\CSharp\CsTextParser.cs" />
-    <Compile Include="Parsers\CSharp\ICsParser.cs" />
+    <Compile Include="Parsers\CSharp\AssemblyWalker.cs" />
+    <Compile Include="Parsers\CSharp\CsAssemblyParser.cs" />
+    <Compile Include="Parsers\CSharp\CsSourceParser.cs" />
+    <Compile Include="Parsers\CSharp\ICsAssemblyParser.cs" />
+    <Compile Include="Parsers\CSharp\ICsSourceParser.cs" />
     <Compile Include="Exceptions\CsParsingException.cs" />
     <Compile Include="Parsers\VisualStudio\IProjectParser.cs" />
     <Compile Include="Parsers\VisualStudio\ISolutionParser.cs" />

--- a/DocNet.Core/DocNet.Core.csproj
+++ b/DocNet.Core/DocNet.Core.csproj
@@ -78,6 +78,7 @@
     <Compile Include="..\.global\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AssemblyXmlPair.cs" />
     <Compile Include="ControllerConfiguration.cs" />
     <Compile Include="DocumentationSettings.cs" />
     <Compile Include="Exceptions\ConfigurationException.cs" />

--- a/DocNet.Core/DocNetController.cs
+++ b/DocNet.Core/DocNetController.cs
@@ -22,7 +22,7 @@ namespace DocNet.Core
 
         private readonly ISolutionParser _solutionParser;
         private readonly IProjectParser _projectParser;
-        private readonly ICsParser _csParser;
+        private readonly ICsSourceParser _csSourceParser;
         private readonly IDocumentationGenerator _documentationGenerator;
         private readonly string _rootDirectoryName;
 
@@ -37,7 +37,7 @@ namespace DocNet.Core
 
             _solutionParser = config.SolutionParser;
             _projectParser = config.ProjectParser;
-            _csParser = config.CsParser;
+            _csSourceParser = config.CsSourceParser;
             _documentationGenerator = config.DocumentationGenerator;
             _rootDirectoryName = config.RootDirectoryName;
         }
@@ -119,7 +119,7 @@ namespace DocNet.Core
         {
             using (var csFile = File.OpenRead(csFilePath))
             {
-                _csParser.ParseIntoNamespace(csFile, globalNamespace, mode);
+                _csSourceParser.ParseIntoNamespace(csFile, globalNamespace, mode);
             }
         }
 

--- a/DocNet.Core/IDocNetController.cs
+++ b/DocNet.Core/IDocNetController.cs
@@ -1,7 +1,11 @@
-﻿namespace DocNet.Core
+﻿using System.Collections.Generic;
+
+namespace DocNet.Core
+
 {
     public interface IDocNetController
     {
-        DocNetStatus Execute(DocumentationSettings settings);
+        DocNetStatus ExecuteSourceParser(IEnumerable<string> inputPaths, string outputPath, OutputMode mode = OutputMode.PublicOnly);
+        DocNetStatus ExecuteAssemblyParser(IEnumerable<AssemblyXmlPair> inputPairs, string outputPath, OutputMode mode = OutputMode.PublicOnly);
     }
 }

--- a/DocNet.Core/Models/Comments/Xml/XmlDocFileSchema.cs
+++ b/DocNet.Core/Models/Comments/Xml/XmlDocFileSchema.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+using System.Xml.Serialization;
+
+namespace DocNet.Core.Models.Comments.Xml
+{
+    [Serializable]
+    [XmlRoot(ElementName = "doc")]
+    public class DocFileModel : IEquatable<DocFileModel>
+    {
+        private Dictionary<string, Member> _nameMemberMap;
+
+        [XmlElement("assembly")]
+        public AssemblyModel AssemblyModel { get; set; }
+
+        private List<Member> _members;
+        [XmlElement(ElementName = "members")]
+        public List<Member> Members {
+            get { return _members; }
+            set
+            {
+                _members = value;
+                GenerateMemberNameMapping();
+            } 
+        }
+
+        public DocFileModel()
+        {
+            Members = new List<Member>();
+        }
+
+        private void GenerateMemberNameMapping()
+        {
+            if (_members == null)
+            {
+                _nameMemberMap = null;
+                return;
+            }
+            _nameMemberMap = new Dictionary<string, Member>();
+            foreach (Member m in _members)
+            {
+                // Todo
+            }
+        }
+
+        public Member GetMemberByFullName(string fullName)
+        {
+            if (_nameMemberMap == null || !_nameMemberMap.ContainsKey(fullName))
+                return null;
+
+            return _nameMemberMap[fullName];
+        }
+
+        #region Equality Members
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = AssemblyModel != null ? AssemblyModel.GetHashCode() : 0;
+                return (hashCode * 397) ^ (Members != null ? Members.GetHashCode() : 0);
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as DocFileModel);
+        }
+
+        public bool Equals(DocFileModel other)
+        {
+            if (other == null) return false;
+            if (this == other) return true;
+            return AssemblyModel == null ? (other.AssemblyModel == null) : AssemblyModel.Equals(other.AssemblyModel)
+                && Members == null ? (other.Members == null) : Members.SequenceEqual(other.Members);
+        }
+
+        #endregion
+    }
+
+    [Serializable]
+    [XmlType(TypeName = "assembly")]
+    public class AssemblyModel : IEquatable<AssemblyModel>
+    {
+        [XmlElement(ElementName = "name")]
+        public string Name { get; set; }
+
+        #region Equality Members
+
+        public override int GetHashCode()
+        {
+            return Name != null ? Name.GetHashCode() : 0;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AssemblyModel);
+        }
+
+        public bool Equals(AssemblyModel other)
+        {
+            if (other == null) return false;
+            if (this == other) return true;
+            return String.Equals(Name, other.Name);
+        }
+
+        #endregion
+    }
+
+    [Serializable]
+    [XmlType(TypeName = "member")]
+    public class Member : IEquatable<Member>
+    {
+        private static readonly Regex MemberNameRegex = new Regex(@"\A(N|T|F|P|M|E|!):([^\s]+)\Z");
+
+        public DocFileMemberType MemberType { get; set; }
+
+        private string _fullMemberName;
+        [XmlAttribute("name")]
+        public string FullMemberName
+        {
+            get { return _fullMemberName; }
+            set
+            {
+                if (!MemberNameIsValid(value))
+                    throw new SerializationException("");
+                _fullMemberName = value;
+                MemberType = GetMembertypeFromChar(_fullMemberName[0]);
+            }
+        }
+
+        [XmlText(typeof(string))]
+        public List<object> Items;  
+
+        public Member()
+        {
+            Items = new List<object>();
+        }
+
+        #region Equality Members
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = FullMemberName != null ? FullMemberName.GetHashCode() : 0;
+                hashCode = (hashCode*397) ^ MemberType.GetHashCode(); 
+                return hashCode;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Member);
+        }
+
+        public bool Equals(Member other)
+        {
+            if (other == null) return false;
+            if (this == other) return true;
+            return String.Equals(FullMemberName, other.FullMemberName)
+                   && MemberType == other.MemberType
+                   && (Items == null) ? (other.Items == null) : Items.SequenceEqual(other.Items);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private static bool MemberNameIsValid(string name)
+        {
+            return name != null && MemberNameRegex.Match(name).Success;
+        }
+
+        private DocFileMemberType GetMembertypeFromChar(char firstCharacter)
+        {
+            switch (firstCharacter)
+            {
+                case 'M':
+                    return DocFileMemberType.Method;
+                case 'T':
+                    return DocFileMemberType.Type;
+                case 'P':
+                    return DocFileMemberType.Property;
+                case 'N':
+                    return DocFileMemberType.Namespace;
+                case 'F':
+                    return DocFileMemberType.Field;
+                case 'E':
+                    return DocFileMemberType.Event;
+            }
+            throw new ArgumentException("Invalid first character for member element name: " + firstCharacter);
+        }
+
+        #endregion
+    }
+
+    public enum DocFileMemberType
+    {
+        Field,
+        Property,
+        Method,
+        Type,
+        Event,
+        Namespace
+    }
+}

--- a/DocNet.Core/Parsers/CSharp/AssemblyWalker.cs
+++ b/DocNet.Core/Parsers/CSharp/AssemblyWalker.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace DocNet.Core.Parsers.CSharp
+{
+    public abstract class AssemblyWalker
+    {
+        private readonly Assembly _assembly;
+
+        protected AssemblyWalker(Assembly assembly)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException("assembly");
+            _assembly = assembly;
+        }
+
+        public virtual void VisitAssembly()
+        {
+            var namespaceList = _assembly.GetTypes().Select(t => t.Namespace).Distinct().ToList();
+            foreach (var namespaceName in namespaceList)
+            {
+                VisitNamespace(namespaceName);
+            }
+        }
+
+        public virtual void VisitNamespace(string namespaceName)
+        {
+            IList<Type> namespaceElements = namespaceName == null ? 
+                _assembly.GetTypes().Where(t => t.Namespace == null).ToList()
+                : _assembly.GetTypes().Where(t => t.Namespace != null && t.Namespace.Equals(namespaceName)).ToList();
+            foreach (Type t in namespaceElements)
+            {
+                VisitType(t);
+            }
+        }
+
+        public virtual void VisitType(Type t)
+        {
+            if (IsDelegate(t))
+            {
+                VisitDelegate(t);
+            }
+            else if (t.IsClass)
+            {
+                VisitClass(t);
+            }
+            else if (t.IsInterface)
+            {
+                VisitInterface(t);
+            }
+            else if (t.IsValueType)
+            {
+                if (t.IsEnum)
+                {
+                    VisitEnum(t);
+                }
+                else
+                {
+                    VisitStruct(t);
+                }
+            }
+        }
+
+        public virtual void VisitClass(Type t)
+        {
+            IterateMembersOfType(t);
+        }
+
+        public virtual void VisitInterface(Type t)
+        {
+            IterateMembersOfType(t);   
+        }
+
+        public virtual void VisitStruct(Type t)
+        {
+            IterateMembersOfType(t);
+        }
+
+        public virtual void VisitEnum(Type t)
+        {
+
+        }
+
+        public virtual void VisitDelegate(Type t)
+        {
+            
+        }
+
+        public virtual void VisitConstructor(ConstructorInfo constructorInfo)
+        {
+            
+        }
+
+        public virtual void VisitMethod(MethodInfo methodInfo)
+        {
+            
+        }
+
+        public virtual void VisitProperty(PropertyInfo propertyInfo)
+        {
+            
+        }
+
+        public virtual void VisitField(FieldInfo fieldInfo)
+        {
+            
+        }
+
+        public virtual void VisitEvent(EventInfo eventInfo)
+        {
+            
+        }
+
+        #region Helper Methods
+
+        private bool IsDelegate(Type t)
+        {
+            return typeof(MulticastDelegate).IsAssignableFrom(t.BaseType);
+        }
+
+        private void IterateMembersOfType(Type t)
+        {
+            foreach (var member in t.GetMembers())
+            {
+                switch (member.MemberType)
+                {
+                    case MemberTypes.Method:
+                        VisitMethod(member as MethodInfo);
+                        break;
+                    case MemberTypes.Property:
+                        VisitProperty(member as PropertyInfo);
+                        break;
+                    case MemberTypes.Constructor:
+                        VisitConstructor(member as ConstructorInfo);
+                        break;
+                    case MemberTypes.Field:
+                        VisitField(member as FieldInfo);
+                        break;
+                    case MemberTypes.Event:
+                        VisitEvent(member as EventInfo);
+                        break;
+                    case MemberTypes.NestedType:
+                    case MemberTypes.TypeInfo:
+                        VisitType(((TypeInfo)member).AsType());
+                        break;
+                }
+            }
+        }
+
+        #endregion 
+    }
+}

--- a/DocNet.Core/Parsers/CSharp/CsAssemblyParser.cs
+++ b/DocNet.Core/Parsers/CSharp/CsAssemblyParser.cs
@@ -27,6 +27,8 @@ namespace DocNet.Core.Parsers.CSharp
                 throw new ArgumentNullException("assembly");
             if (docFileXml == null)
                 throw new ArgumentNullException("docFileXml");
+            if (globalNamespace == null)
+                throw new ArgumentNullException("globalNamespace");
 
             var docFileModel = DeserializeDocFileXmlString(docFileXml);
 
@@ -34,9 +36,32 @@ namespace DocNet.Core.Parsers.CSharp
             walker.VisitAssembly();
         }
 
+        public GlobalNamespaceModel GetGlobalNamespace(Assembly assembly, FileStream docFile, OutputMode outputMode)
+        {
+            var globalNamespace = new GlobalNamespaceModel();
+            ParseIntoNamespace(assembly, docFile, globalNamespace, outputMode);
+            return globalNamespace;
+        }
+
+        public void ParseIntoNamespace(Assembly assembly, FileStream docFile, GlobalNamespaceModel globalNamespace,
+            OutputMode outputMode)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException("assembly");
+            if (docFile == null)
+                throw new ArgumentNullException("docFile");
+            if (globalNamespace == null)
+                throw new ArgumentNullException("globalNamespace");
+
+            var docFileModel = DeserializeDocFileXmlString(docFile);
+
+            var walker = new CsAssemblyWalker(globalNamespace, assembly, docFileModel, outputMode);
+            walker.VisitAssembly();
+        }
+
         #region Helper Methods
 
-        private DocFileModel DeserializeDocFileXmlString(string docFileXml)
+        private static DocFileModel DeserializeDocFileXmlString(string docFileXml)
         {
             XmlSerializer serializer = new XmlSerializer(typeof(DocFileModel));
             using (var reader = new XmlTextReader(new StringReader(docFileXml)))
@@ -49,7 +74,7 @@ namespace DocNet.Core.Parsers.CSharp
             return null;
         }
 
-        private DocFileModel DeserializeDocFileXmlString(Stream xmlDocFile)
+        private static DocFileModel DeserializeDocFileXmlString(Stream xmlDocFile)
         {
             XmlSerializer serializer = new XmlSerializer(typeof(DocFileModel));
             using (var reader = new XmlTextReader(new StreamReader(xmlDocFile)))
@@ -63,393 +88,392 @@ namespace DocNet.Core.Parsers.CSharp
         }
 
         #endregion
-
-        internal class CsAssemblyWalker : AssemblyWalker
-        {
-            private GlobalNamespaceModel _globalNamespace;
-            private readonly OutputMode _outputMode;
-            private readonly DocFileModel _docFileModel;
-            private IParentElement _currentParent;
-
-            public CsAssemblyWalker(GlobalNamespaceModel globalNamespace, Assembly assembly, DocFileModel docFileModel, OutputMode outputMode) : base(assembly)
-            {
-                if(globalNamespace == null)
-                    throw new ArgumentNullException("globalNamespace");
-                if(docFileModel == null)
-                    throw new ArgumentNullException("docFileModel");
-
-                _globalNamespace = globalNamespace;
-                _currentParent = globalNamespace;
-                _docFileModel = docFileModel;
-                _outputMode = outputMode;
-            }
-
-            #region Visitors
-
-            public override void VisitNamespace(string namespaceName)
-            {
-                if (namespaceName == null)
-                    throw new ArgumentNullException("namespaceName");
-
-                var namespaceModel = new NamespaceModel
-                {
-                    Identifier = namespaceName
-                };
-
-                // Update current parent
-                var oldParent = _currentParent;
-                _currentParent = namespaceModel;
-
-                base.VisitNamespace(namespaceName);
-
-                // Restore old parent
-                _currentParent = oldParent;
-
-                _currentParent.AddChild(namespaceModel);
-            }
-
-            public override void VisitClass(Type t)
-            {
-                if (t == null)
-                    throw new ArgumentNullException("t");
-
-                var classModel = new ClassModel
-                {
-                    Identifier = t.Name,
-                    TypeParameters = GetTypeParameterList(t),
-                    IsAbstract = t.IsAbstract,
-                    IsSealed = t.IsSealed,
-                    IsStatic = t.IsSealed && t.IsAbstract, // Static classes are internally just sealed abstract classes
-                    AccessModifier = GetAccessModifierForType(t),
-                    InheritanceList = GetInheritanceListForType(t)
-                };
-
-                // Update current parent
-                var oldParent = _currentParent;
-                _currentParent = classModel;
-
-                base.VisitClass(t);
-
-                // Restore old parent
-                _currentParent = oldParent;
-
-                if (InterfaceTypeShouldBeAdded(classModel))
-                {
-                    _currentParent.AddChild(classModel);
-                }
-            }
-
-            public override void VisitInterface(Type t)
-            {
-                if (t == null)
-                    throw new ArgumentNullException("t");
-
-                var interfaceModel = new InterfaceModel
-                {
-                    Identifier = t.Name,
-                    TypeParameters = GetTypeParameterList(t),
-                    AccessModifier = GetAccessModifierForType(t),
-                    InheritanceList = GetInheritanceListForType(t)
-                };
-
-                // Update current parent
-                var oldParent = _currentParent;
-                _currentParent = interfaceModel;
-
-                base.VisitInterface(t);
-
-                // Restore old parent
-                _currentParent = oldParent;
-
-                if (InterfaceTypeShouldBeAdded(interfaceModel))
-                {
-                    _currentParent.AddChild(interfaceModel);
-                }
-            }
-
-            public override void VisitStruct(Type t)
-            {
-                if (t == null)
-                    throw new ArgumentNullException("t");
-
-                var structModel = new StructModel
-                {
-                    Identifier = t.Name,
-                    TypeParameters = GetTypeParameterList(t),
-                    AccessModifier = GetAccessModifierForType(t),
-                    InheritanceList = GetInheritanceListForType(t)
-                };
-                
-                // Update current parent
-                var oldParent = _currentParent;
-                _currentParent = structModel;
-
-                base.VisitStruct(t);
-
-                // Restore old parent
-                _currentParent = oldParent;
-
-                if (InterfaceTypeShouldBeAdded(structModel))
-                {
-                    _currentParent.AddChild(structModel);
-                }
-            }
-
-            public override void VisitEnum(Type t)
-            {
-                if (t == null)
-                    throw new ArgumentNullException("t");
-
-                var enumModel = new EnumModel
-                {
-                    Identifier = t.Name,
-                    AccessModifier = GetAccessModifierForType(t),
-                    Fields = t.GetEnumNames()
-                };
-
-                base.VisitEnum(t);
-
-                if (NestedTypeShouldBeAdded(enumModel.AccessModifier, enumModel.DocComment == null))
-                {
-                    _currentParent.AddChild(enumModel);
-                }
-            }
-
-            public override void VisitDelegate(Type t)
-            {
-                if (t == null)
-                    throw new ArgumentNullException("t");
-
-                var delegateModel = new DelegateModel
-                {
-                    Identifier = t.Name,
-                    TypeParameters = GetTypeParameterList(t),
-                    AccessModifier = GetAccessModifierForType(t)
-                };
-
-                base.VisitDelegate(t);
-
-                if (NestedTypeShouldBeAdded(delegateModel.AccessModifier, delegateModel.DocComment == null))
-                {
-                    _currentParent.AddChild(delegateModel);
-                }
-            }
-
-            public override void VisitConstructor(ConstructorInfo constructorInfo)
-            {
-                if (constructorInfo == null)
-                    throw new ArgumentNullException("constructorInfo");
-
-                var constructorModel = new ConstructorModel
-                {
-                    Identifier = constructorInfo.Name,
-                    IsStatic = constructorInfo.IsStatic,
-                };
-
-                base.VisitConstructor(constructorInfo);
-
-                if (NestedTypeShouldBeAdded(constructorModel.AccessModifier, constructorModel.DocComment == null))
-                {
-                    _currentParent.AddChild(constructorModel);
-                }
-            }
-
-            public override void VisitMethod(MethodInfo methodInfo)
-            {
-                if (methodInfo == null)
-                    throw new ArgumentNullException("methodInfo");
-
-                var methodModel = new MethodModel
-                {
-                    Identifier = methodInfo.Name
-                };
-
-                base.VisitMethod(methodInfo);
-
-                if (NestedTypeShouldBeAdded(methodModel.AccessModifier, methodModel.DocComment == null))
-                {
-                    _currentParent.AddChild(methodModel);
-                }
-            }
-
-            public override void VisitProperty(PropertyInfo propertyInfo)
-            {
-                if (propertyInfo == null)
-                    throw new ArgumentNullException("propertyInfo");
-
-                var propertyModel = new PropertyModel
-                {
-                    Identifier = propertyInfo.Name
-                };
-
-                base.VisitProperty(propertyInfo);
-
-                if (NestedTypeShouldBeAdded(propertyModel.AccessModifier, propertyModel.DocComment == null))
-                {
-                    _currentParent.AddChild(propertyModel);
-                }
-            }
-
-            public override void VisitField(FieldInfo fieldInfo)
-            {
-                if (fieldInfo == null)
-                    throw new ArgumentNullException("fieldInfo");
-
-                base.VisitField(fieldInfo);
-            }
-
-            public override void VisitEvent(EventInfo eventInfo)
-            {
-                if(eventInfo == null)
-                    throw new ArgumentNullException("eventInfo");
-
-                base.VisitEvent(eventInfo);
-            }
-
-            #endregion
-
-            #region Helper Methods
-
-            #region Doc Comments
-
-
-            #endregion
-
-            #region Modifiers
-
-            // See https://msdn.microsoft.com/en-us/library/ms173183.aspx?f=255&MSPPError=-2147217396 
-            // for more info on access modifiers in IL
-            private static AccessModifier GetAccessModifierForType(Type t)
-            {
-                if (t.IsPublic)
-                    return AccessModifier.Public;
-
-                if (t.IsNestedFamORAssem)
-                    return AccessModifier.ProtectedInternal;
-
-                // ToDo: Determine how to identify internal classes
-
-                return AccessModifier.Internal;
-            }
-
-            private static AccessModifier GetAccessModifierForConstructor(ConstructorInfo constructorInfo)
-            {
-                if (constructorInfo.IsPrivate)
-                    return AccessModifier.Public;
-                if (constructorInfo.IsPrivate)
-                    return AccessModifier.Private;
-                if (constructorInfo.IsFamilyOrAssembly)
-                    return AccessModifier.ProtectedInternal;
-                if (constructorInfo.IsFamily)
-                    return AccessModifier.Protected;
-                return AccessModifier.Internal;
-            }
-
-            private static AccessModifier GetAccessModifierForMethod(MethodInfo methodInfo)
-            {
-                if (methodInfo.IsPrivate)
-                    return AccessModifier.Public;
-                if (methodInfo.IsPrivate)
-                    return AccessModifier.Private;
-                if (methodInfo.IsFamilyOrAssembly)
-                    return AccessModifier.ProtectedInternal;
-                if (methodInfo.IsFamily)
-                    return AccessModifier.Protected;
-                return AccessModifier.Internal;
-            }
-
-            #endregion
-
-            #region Parameters
-
-            private static IList<TypeParameterModel> GetTypeParameterList(Type t)
-            {
-                return t.GenericTypeArguments.Select(typeParam => new TypeParameterModel
-                {
-                    Name = typeParam.Name,
-                    Constraint = GetGenericParameterConstraintForType(typeParam)
-                }).ToList();
-            }
-
-            private static string GetGenericParameterConstraintForType(Type t)
-            {
-                var genericParameterAttributes = t.GenericParameterAttributes;
-                var specialConstraints = genericParameterAttributes & GenericParameterAttributes.SpecialConstraintMask;
-                if (specialConstraints != GenericParameterAttributes.None)
-                {
-                    if ((specialConstraints & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
-                    {
-                        
-                    }
-                    if ((specialConstraints & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
-                    {
-                        
-                    }
-                    if ((specialConstraints & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
-                    {
-                        
-                    }
-                }
-                
-                var typeConstraints = t.GetGenericParameterConstraints();
-                if (typeConstraints.Any())
-                {
-                    
-                }
-                return null;
-            }
-
-            #endregion
-
-            private static IList<string> GetInheritanceListForType(Type t)
-            {
-                var inheritanceList = new List<string>();
-                if (t.BaseType != null && t.BaseType != typeof (object))
-                {
-                    inheritanceList.Add(t.BaseType.Name);
-                }
-                inheritanceList.AddRange(t.GetInterfaces().Select(i => i.Name).ToList());
-                return inheritanceList;
-            }
-
-            #region Selection Rules
-
-            private bool InterfaceTypeShouldBeAdded(InterfaceBase interfaceBase)
-            {
-                // Todo: Should include include undocumented elements with documented children
-                switch (_outputMode)
-                {
-                    case OutputMode.PublicOnly:
-                        return interfaceBase.AccessModifier == AccessModifier.Public;
-                    case OutputMode.DocumentedOnly:
-                        return interfaceBase.DocComment != null;
-                    case OutputMode.PublicDocumentedOnly:
-                        return interfaceBase.AccessModifier == AccessModifier.Public && interfaceBase.DocComment != null;
-                    default:
-                        return true;
-                }
-            }
-
-            public bool NestedTypeShouldBeAdded(AccessModifier accessModifier, bool hasDocComment)
-            {
-                switch (_outputMode)
-                {
-                    case OutputMode.PublicOnly:
-                        return accessModifier == AccessModifier.Public;
-                    case OutputMode.DocumentedOnly:
-                        return hasDocComment;
-                    case OutputMode.PublicDocumentedOnly:
-                        return accessModifier == AccessModifier.Public && hasDocComment;
-                    default:
-                        return true;
-                }
-            }
-
-            #endregion
-
-            #endregion
-        }
     }
 
+    internal class CsAssemblyWalker : AssemblyWalker
+    {
+        private GlobalNamespaceModel _globalNamespace;
+        private readonly OutputMode _outputMode;
+        private readonly DocFileModel _docFileModel;
+        private IParentElement _currentParent;
 
+        public CsAssemblyWalker(GlobalNamespaceModel globalNamespace, Assembly assembly, DocFileModel docFileModel, OutputMode outputMode)
+            : base(assembly)
+        {
+            if (globalNamespace == null)
+                throw new ArgumentNullException("globalNamespace");
+            if (docFileModel == null)
+                throw new ArgumentNullException("docFileModel");
+
+            _globalNamespace = globalNamespace;
+            _currentParent = globalNamespace;
+            _docFileModel = docFileModel;
+            _outputMode = outputMode;
+        }
+
+        #region Visitors
+
+        public override void VisitNamespace(string namespaceName)
+        {
+            if (namespaceName == null)
+                throw new ArgumentNullException("namespaceName");
+
+            var namespaceModel = new NamespaceModel
+            {
+                Identifier = namespaceName
+            };
+
+            // Update current parent
+            var oldParent = _currentParent;
+            _currentParent = namespaceModel;
+
+            base.VisitNamespace(namespaceName);
+
+            // Restore old parent
+            _currentParent = oldParent;
+
+            _currentParent.AddChild(namespaceModel);
+        }
+
+        public override void VisitClass(Type t)
+        {
+            if (t == null)
+                throw new ArgumentNullException("t");
+
+            var classModel = new ClassModel
+            {
+                Identifier = t.Name,
+                TypeParameters = GetTypeParameterList(t),
+                IsAbstract = t.IsAbstract,
+                IsSealed = t.IsSealed,
+                IsStatic = t.IsSealed && t.IsAbstract, // Static classes are internally just sealed abstract classes
+                AccessModifier = GetAccessModifierForType(t),
+                InheritanceList = GetInheritanceListForType(t)
+            };
+
+            // Update current parent
+            var oldParent = _currentParent;
+            _currentParent = classModel;
+
+            base.VisitClass(t);
+
+            // Restore old parent
+            _currentParent = oldParent;
+
+            if (InterfaceTypeShouldBeAdded(classModel))
+            {
+                _currentParent.AddChild(classModel);
+            }
+        }
+
+        public override void VisitInterface(Type t)
+        {
+            if (t == null)
+                throw new ArgumentNullException("t");
+
+            var interfaceModel = new InterfaceModel
+            {
+                Identifier = t.Name,
+                TypeParameters = GetTypeParameterList(t),
+                AccessModifier = GetAccessModifierForType(t),
+                InheritanceList = GetInheritanceListForType(t)
+            };
+
+            // Update current parent
+            var oldParent = _currentParent;
+            _currentParent = interfaceModel;
+
+            base.VisitInterface(t);
+
+            // Restore old parent
+            _currentParent = oldParent;
+
+            if (InterfaceTypeShouldBeAdded(interfaceModel))
+            {
+                _currentParent.AddChild(interfaceModel);
+            }
+        }
+
+        public override void VisitStruct(Type t)
+        {
+            if (t == null)
+                throw new ArgumentNullException("t");
+
+            var structModel = new StructModel
+            {
+                Identifier = t.Name,
+                TypeParameters = GetTypeParameterList(t),
+                AccessModifier = GetAccessModifierForType(t),
+                InheritanceList = GetInheritanceListForType(t)
+            };
+
+            // Update current parent
+            var oldParent = _currentParent;
+            _currentParent = structModel;
+
+            base.VisitStruct(t);
+
+            // Restore old parent
+            _currentParent = oldParent;
+
+            if (InterfaceTypeShouldBeAdded(structModel))
+            {
+                _currentParent.AddChild(structModel);
+            }
+        }
+
+        public override void VisitEnum(Type t)
+        {
+            if (t == null)
+                throw new ArgumentNullException("t");
+
+            var enumModel = new EnumModel
+            {
+                Identifier = t.Name,
+                AccessModifier = GetAccessModifierForType(t),
+                Fields = t.GetEnumNames()
+            };
+
+            base.VisitEnum(t);
+
+            if (NestedTypeShouldBeAdded(enumModel.AccessModifier, enumModel.DocComment == null))
+            {
+                _currentParent.AddChild(enumModel);
+            }
+        }
+
+        public override void VisitDelegate(Type t)
+        {
+            if (t == null)
+                throw new ArgumentNullException("t");
+
+            var delegateModel = new DelegateModel
+            {
+                Identifier = t.Name,
+                TypeParameters = GetTypeParameterList(t),
+                AccessModifier = GetAccessModifierForType(t)
+            };
+
+            base.VisitDelegate(t);
+
+            if (NestedTypeShouldBeAdded(delegateModel.AccessModifier, delegateModel.DocComment == null))
+            {
+                _currentParent.AddChild(delegateModel);
+            }
+        }
+
+        public override void VisitConstructor(ConstructorInfo constructorInfo)
+        {
+            if (constructorInfo == null)
+                throw new ArgumentNullException("constructorInfo");
+
+            var constructorModel = new ConstructorModel
+            {
+                Identifier = constructorInfo.Name,
+                IsStatic = constructorInfo.IsStatic,
+            };
+
+            base.VisitConstructor(constructorInfo);
+
+            if (NestedTypeShouldBeAdded(constructorModel.AccessModifier, constructorModel.DocComment == null))
+            {
+                _currentParent.AddChild(constructorModel);
+            }
+        }
+
+        public override void VisitMethod(MethodInfo methodInfo)
+        {
+            if (methodInfo == null)
+                throw new ArgumentNullException("methodInfo");
+
+            var methodModel = new MethodModel
+            {
+                Identifier = methodInfo.Name
+            };
+
+            base.VisitMethod(methodInfo);
+
+            if (NestedTypeShouldBeAdded(methodModel.AccessModifier, methodModel.DocComment == null))
+            {
+                _currentParent.AddChild(methodModel);
+            }
+        }
+
+        public override void VisitProperty(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo == null)
+                throw new ArgumentNullException("propertyInfo");
+
+            var propertyModel = new PropertyModel
+            {
+                Identifier = propertyInfo.Name
+            };
+
+            base.VisitProperty(propertyInfo);
+
+            if (NestedTypeShouldBeAdded(propertyModel.AccessModifier, propertyModel.DocComment == null))
+            {
+                _currentParent.AddChild(propertyModel);
+            }
+        }
+
+        public override void VisitField(FieldInfo fieldInfo)
+        {
+            if (fieldInfo == null)
+                throw new ArgumentNullException("fieldInfo");
+
+            base.VisitField(fieldInfo);
+        }
+
+        public override void VisitEvent(EventInfo eventInfo)
+        {
+            if (eventInfo == null)
+                throw new ArgumentNullException("eventInfo");
+
+            base.VisitEvent(eventInfo);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        #region Doc Comments
+
+
+        #endregion
+
+        #region Modifiers
+
+        // See https://msdn.microsoft.com/en-us/library/ms173183.aspx?f=255&MSPPError=-2147217396 
+        // for more info on access modifiers in IL
+        private static AccessModifier GetAccessModifierForType(Type t)
+        {
+            if (t.IsPublic)
+                return AccessModifier.Public;
+
+            if (t.IsNestedFamORAssem)
+                return AccessModifier.ProtectedInternal;
+
+            // ToDo: Determine how to identify internal classes
+
+            return AccessModifier.Internal;
+        }
+
+        private static AccessModifier GetAccessModifierForConstructor(ConstructorInfo constructorInfo)
+        {
+            if (constructorInfo.IsPrivate)
+                return AccessModifier.Public;
+            if (constructorInfo.IsPrivate)
+                return AccessModifier.Private;
+            if (constructorInfo.IsFamilyOrAssembly)
+                return AccessModifier.ProtectedInternal;
+            if (constructorInfo.IsFamily)
+                return AccessModifier.Protected;
+            return AccessModifier.Internal;
+        }
+
+        private static AccessModifier GetAccessModifierForMethod(MethodInfo methodInfo)
+        {
+            if (methodInfo.IsPrivate)
+                return AccessModifier.Public;
+            if (methodInfo.IsPrivate)
+                return AccessModifier.Private;
+            if (methodInfo.IsFamilyOrAssembly)
+                return AccessModifier.ProtectedInternal;
+            if (methodInfo.IsFamily)
+                return AccessModifier.Protected;
+            return AccessModifier.Internal;
+        }
+
+        #endregion
+
+        #region Parameters
+
+        private static IList<TypeParameterModel> GetTypeParameterList(Type t)
+        {
+            return t.GenericTypeArguments.Select(typeParam => new TypeParameterModel
+            {
+                Name = typeParam.Name,
+                Constraint = GetGenericParameterConstraintForType(typeParam)
+            }).ToList();
+        }
+
+        private static string GetGenericParameterConstraintForType(Type t)
+        {
+            var genericParameterAttributes = t.GenericParameterAttributes;
+            var specialConstraints = genericParameterAttributes & GenericParameterAttributes.SpecialConstraintMask;
+            if (specialConstraints != GenericParameterAttributes.None)
+            {
+                if ((specialConstraints & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+                {
+
+                }
+                if ((specialConstraints & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+                {
+
+                }
+                if ((specialConstraints & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
+                {
+
+                }
+            }
+
+            var typeConstraints = t.GetGenericParameterConstraints();
+            if (typeConstraints.Any())
+            {
+
+            }
+            return null;
+        }
+
+        #endregion
+
+        private static IList<string> GetInheritanceListForType(Type t)
+        {
+            var inheritanceList = new List<string>();
+            if (t.BaseType != null && t.BaseType != typeof(object))
+            {
+                inheritanceList.Add(t.BaseType.Name);
+            }
+            inheritanceList.AddRange(t.GetInterfaces().Select(i => i.Name).ToList());
+            return inheritanceList;
+        }
+
+        #region Selection Rules
+
+        private bool InterfaceTypeShouldBeAdded(InterfaceBase interfaceBase)
+        {
+            // Todo: Should include include undocumented elements with documented children
+            switch (_outputMode)
+            {
+                case OutputMode.PublicOnly:
+                    return interfaceBase.AccessModifier == AccessModifier.Public;
+                case OutputMode.DocumentedOnly:
+                    return interfaceBase.DocComment != null;
+                case OutputMode.PublicDocumentedOnly:
+                    return interfaceBase.AccessModifier == AccessModifier.Public && interfaceBase.DocComment != null;
+                default:
+                    return true;
+            }
+        }
+
+        public bool NestedTypeShouldBeAdded(AccessModifier accessModifier, bool hasDocComment)
+        {
+            switch (_outputMode)
+            {
+                case OutputMode.PublicOnly:
+                    return accessModifier == AccessModifier.Public;
+                case OutputMode.DocumentedOnly:
+                    return hasDocComment;
+                case OutputMode.PublicDocumentedOnly:
+                    return accessModifier == AccessModifier.Public && hasDocComment;
+                default:
+                    return true;
+            }
+        }
+
+        #endregion
+
+        #endregion
+    }
 }

--- a/DocNet.Core/Parsers/CSharp/CsAssemblyParser.cs
+++ b/DocNet.Core/Parsers/CSharp/CsAssemblyParser.cs
@@ -1,0 +1,455 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Serialization;
+using DocNet.Core.Models.Comments.Xml;
+using DocNet.Core.Models.CSharp;
+using Assembly = System.Reflection.Assembly;
+
+namespace DocNet.Core.Parsers.CSharp
+{
+    public class CsAssemblyParser : ICsAssemblyParser
+    {
+        public GlobalNamespaceModel GetGlobalNamespace(Assembly assembly, string docFileXml, OutputMode outputMode)
+        {
+            var globalNamespace = new GlobalNamespaceModel();
+            ParseIntoNamespace(assembly, docFileXml, globalNamespace, outputMode);
+            return globalNamespace;
+        }
+
+        public void ParseIntoNamespace(Assembly assembly, string docFileXml, GlobalNamespaceModel globalNamespace, OutputMode outputMode)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException("assembly");
+            if (docFileXml == null)
+                throw new ArgumentNullException("docFileXml");
+
+            var docFileModel = DeserializeDocFileXmlString(docFileXml);
+
+            var walker = new CsAssemblyWalker(globalNamespace, assembly, docFileModel, outputMode);
+            walker.VisitAssembly();
+        }
+
+        #region Helper Methods
+
+        private DocFileModel DeserializeDocFileXmlString(string docFileXml)
+        {
+            XmlSerializer serializer = new XmlSerializer(typeof(DocFileModel));
+            using (var reader = new XmlTextReader(new StringReader(docFileXml)))
+            {
+                if (serializer.CanDeserialize(reader))
+                {
+                    return serializer.Deserialize(reader) as DocFileModel;
+                }
+            }
+            return null;
+        }
+
+        private DocFileModel DeserializeDocFileXmlString(Stream xmlDocFile)
+        {
+            XmlSerializer serializer = new XmlSerializer(typeof(DocFileModel));
+            using (var reader = new XmlTextReader(new StreamReader(xmlDocFile)))
+            {
+                if (serializer.CanDeserialize(reader))
+                {
+                    return serializer.Deserialize(reader) as DocFileModel;
+                }
+            }
+            return null;
+        }
+
+        #endregion
+
+        internal class CsAssemblyWalker : AssemblyWalker
+        {
+            private GlobalNamespaceModel _globalNamespace;
+            private readonly OutputMode _outputMode;
+            private readonly DocFileModel _docFileModel;
+            private IParentElement _currentParent;
+
+            public CsAssemblyWalker(GlobalNamespaceModel globalNamespace, Assembly assembly, DocFileModel docFileModel, OutputMode outputMode) : base(assembly)
+            {
+                if(globalNamespace == null)
+                    throw new ArgumentNullException("globalNamespace");
+                if(docFileModel == null)
+                    throw new ArgumentNullException("docFileModel");
+
+                _globalNamespace = globalNamespace;
+                _currentParent = globalNamespace;
+                _docFileModel = docFileModel;
+                _outputMode = outputMode;
+            }
+
+            #region Visitors
+
+            public override void VisitNamespace(string namespaceName)
+            {
+                if (namespaceName == null)
+                    throw new ArgumentNullException("namespaceName");
+
+                var namespaceModel = new NamespaceModel
+                {
+                    Identifier = namespaceName
+                };
+
+                // Update current parent
+                var oldParent = _currentParent;
+                _currentParent = namespaceModel;
+
+                base.VisitNamespace(namespaceName);
+
+                // Restore old parent
+                _currentParent = oldParent;
+
+                _currentParent.AddChild(namespaceModel);
+            }
+
+            public override void VisitClass(Type t)
+            {
+                if (t == null)
+                    throw new ArgumentNullException("t");
+
+                var classModel = new ClassModel
+                {
+                    Identifier = t.Name,
+                    TypeParameters = GetTypeParameterList(t),
+                    IsAbstract = t.IsAbstract,
+                    IsSealed = t.IsSealed,
+                    IsStatic = t.IsSealed && t.IsAbstract, // Static classes are internally just sealed abstract classes
+                    AccessModifier = GetAccessModifierForType(t),
+                    InheritanceList = GetInheritanceListForType(t)
+                };
+
+                // Update current parent
+                var oldParent = _currentParent;
+                _currentParent = classModel;
+
+                base.VisitClass(t);
+
+                // Restore old parent
+                _currentParent = oldParent;
+
+                if (InterfaceTypeShouldBeAdded(classModel))
+                {
+                    _currentParent.AddChild(classModel);
+                }
+            }
+
+            public override void VisitInterface(Type t)
+            {
+                if (t == null)
+                    throw new ArgumentNullException("t");
+
+                var interfaceModel = new InterfaceModel
+                {
+                    Identifier = t.Name,
+                    TypeParameters = GetTypeParameterList(t),
+                    AccessModifier = GetAccessModifierForType(t),
+                    InheritanceList = GetInheritanceListForType(t)
+                };
+
+                // Update current parent
+                var oldParent = _currentParent;
+                _currentParent = interfaceModel;
+
+                base.VisitInterface(t);
+
+                // Restore old parent
+                _currentParent = oldParent;
+
+                if (InterfaceTypeShouldBeAdded(interfaceModel))
+                {
+                    _currentParent.AddChild(interfaceModel);
+                }
+            }
+
+            public override void VisitStruct(Type t)
+            {
+                if (t == null)
+                    throw new ArgumentNullException("t");
+
+                var structModel = new StructModel
+                {
+                    Identifier = t.Name,
+                    TypeParameters = GetTypeParameterList(t),
+                    AccessModifier = GetAccessModifierForType(t),
+                    InheritanceList = GetInheritanceListForType(t)
+                };
+                
+                // Update current parent
+                var oldParent = _currentParent;
+                _currentParent = structModel;
+
+                base.VisitStruct(t);
+
+                // Restore old parent
+                _currentParent = oldParent;
+
+                if (InterfaceTypeShouldBeAdded(structModel))
+                {
+                    _currentParent.AddChild(structModel);
+                }
+            }
+
+            public override void VisitEnum(Type t)
+            {
+                if (t == null)
+                    throw new ArgumentNullException("t");
+
+                var enumModel = new EnumModel
+                {
+                    Identifier = t.Name,
+                    AccessModifier = GetAccessModifierForType(t),
+                    Fields = t.GetEnumNames()
+                };
+
+                base.VisitEnum(t);
+
+                if (NestedTypeShouldBeAdded(enumModel.AccessModifier, enumModel.DocComment == null))
+                {
+                    _currentParent.AddChild(enumModel);
+                }
+            }
+
+            public override void VisitDelegate(Type t)
+            {
+                if (t == null)
+                    throw new ArgumentNullException("t");
+
+                var delegateModel = new DelegateModel
+                {
+                    Identifier = t.Name,
+                    TypeParameters = GetTypeParameterList(t),
+                    AccessModifier = GetAccessModifierForType(t)
+                };
+
+                base.VisitDelegate(t);
+
+                if (NestedTypeShouldBeAdded(delegateModel.AccessModifier, delegateModel.DocComment == null))
+                {
+                    _currentParent.AddChild(delegateModel);
+                }
+            }
+
+            public override void VisitConstructor(ConstructorInfo constructorInfo)
+            {
+                if (constructorInfo == null)
+                    throw new ArgumentNullException("constructorInfo");
+
+                var constructorModel = new ConstructorModel
+                {
+                    Identifier = constructorInfo.Name,
+                    IsStatic = constructorInfo.IsStatic,
+                };
+
+                base.VisitConstructor(constructorInfo);
+
+                if (NestedTypeShouldBeAdded(constructorModel.AccessModifier, constructorModel.DocComment == null))
+                {
+                    _currentParent.AddChild(constructorModel);
+                }
+            }
+
+            public override void VisitMethod(MethodInfo methodInfo)
+            {
+                if (methodInfo == null)
+                    throw new ArgumentNullException("methodInfo");
+
+                var methodModel = new MethodModel
+                {
+                    Identifier = methodInfo.Name
+                };
+
+                base.VisitMethod(methodInfo);
+
+                if (NestedTypeShouldBeAdded(methodModel.AccessModifier, methodModel.DocComment == null))
+                {
+                    _currentParent.AddChild(methodModel);
+                }
+            }
+
+            public override void VisitProperty(PropertyInfo propertyInfo)
+            {
+                if (propertyInfo == null)
+                    throw new ArgumentNullException("propertyInfo");
+
+                var propertyModel = new PropertyModel
+                {
+                    Identifier = propertyInfo.Name
+                };
+
+                base.VisitProperty(propertyInfo);
+
+                if (NestedTypeShouldBeAdded(propertyModel.AccessModifier, propertyModel.DocComment == null))
+                {
+                    _currentParent.AddChild(propertyModel);
+                }
+            }
+
+            public override void VisitField(FieldInfo fieldInfo)
+            {
+                if (fieldInfo == null)
+                    throw new ArgumentNullException("fieldInfo");
+
+                base.VisitField(fieldInfo);
+            }
+
+            public override void VisitEvent(EventInfo eventInfo)
+            {
+                if(eventInfo == null)
+                    throw new ArgumentNullException("eventInfo");
+
+                base.VisitEvent(eventInfo);
+            }
+
+            #endregion
+
+            #region Helper Methods
+
+            #region Doc Comments
+
+
+            #endregion
+
+            #region Modifiers
+
+            // See https://msdn.microsoft.com/en-us/library/ms173183.aspx?f=255&MSPPError=-2147217396 
+            // for more info on access modifiers in IL
+            private static AccessModifier GetAccessModifierForType(Type t)
+            {
+                if (t.IsPublic)
+                    return AccessModifier.Public;
+
+                if (t.IsNestedFamORAssem)
+                    return AccessModifier.ProtectedInternal;
+
+                // ToDo: Determine how to identify internal classes
+
+                return AccessModifier.Internal;
+            }
+
+            private static AccessModifier GetAccessModifierForConstructor(ConstructorInfo constructorInfo)
+            {
+                if (constructorInfo.IsPrivate)
+                    return AccessModifier.Public;
+                if (constructorInfo.IsPrivate)
+                    return AccessModifier.Private;
+                if (constructorInfo.IsFamilyOrAssembly)
+                    return AccessModifier.ProtectedInternal;
+                if (constructorInfo.IsFamily)
+                    return AccessModifier.Protected;
+                return AccessModifier.Internal;
+            }
+
+            private static AccessModifier GetAccessModifierForMethod(MethodInfo methodInfo)
+            {
+                if (methodInfo.IsPrivate)
+                    return AccessModifier.Public;
+                if (methodInfo.IsPrivate)
+                    return AccessModifier.Private;
+                if (methodInfo.IsFamilyOrAssembly)
+                    return AccessModifier.ProtectedInternal;
+                if (methodInfo.IsFamily)
+                    return AccessModifier.Protected;
+                return AccessModifier.Internal;
+            }
+
+            #endregion
+
+            #region Parameters
+
+            private static IList<TypeParameterModel> GetTypeParameterList(Type t)
+            {
+                return t.GenericTypeArguments.Select(typeParam => new TypeParameterModel
+                {
+                    Name = typeParam.Name,
+                    Constraint = GetGenericParameterConstraintForType(typeParam)
+                }).ToList();
+            }
+
+            private static string GetGenericParameterConstraintForType(Type t)
+            {
+                var genericParameterAttributes = t.GenericParameterAttributes;
+                var specialConstraints = genericParameterAttributes & GenericParameterAttributes.SpecialConstraintMask;
+                if (specialConstraints != GenericParameterAttributes.None)
+                {
+                    if ((specialConstraints & GenericParameterAttributes.ReferenceTypeConstraint) != 0)
+                    {
+                        
+                    }
+                    if ((specialConstraints & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0)
+                    {
+                        
+                    }
+                    if ((specialConstraints & GenericParameterAttributes.DefaultConstructorConstraint) != 0)
+                    {
+                        
+                    }
+                }
+                
+                var typeConstraints = t.GetGenericParameterConstraints();
+                if (typeConstraints.Any())
+                {
+                    
+                }
+                return null;
+            }
+
+            #endregion
+
+            private static IList<string> GetInheritanceListForType(Type t)
+            {
+                var inheritanceList = new List<string>();
+                if (t.BaseType != null && t.BaseType != typeof (object))
+                {
+                    inheritanceList.Add(t.BaseType.Name);
+                }
+                inheritanceList.AddRange(t.GetInterfaces().Select(i => i.Name).ToList());
+                return inheritanceList;
+            }
+
+            #region Selection Rules
+
+            private bool InterfaceTypeShouldBeAdded(InterfaceBase interfaceBase)
+            {
+                // Todo: Should include include undocumented elements with documented children
+                switch (_outputMode)
+                {
+                    case OutputMode.PublicOnly:
+                        return interfaceBase.AccessModifier == AccessModifier.Public;
+                    case OutputMode.DocumentedOnly:
+                        return interfaceBase.DocComment != null;
+                    case OutputMode.PublicDocumentedOnly:
+                        return interfaceBase.AccessModifier == AccessModifier.Public && interfaceBase.DocComment != null;
+                    default:
+                        return true;
+                }
+            }
+
+            public bool NestedTypeShouldBeAdded(AccessModifier accessModifier, bool hasDocComment)
+            {
+                switch (_outputMode)
+                {
+                    case OutputMode.PublicOnly:
+                        return accessModifier == AccessModifier.Public;
+                    case OutputMode.DocumentedOnly:
+                        return hasDocComment;
+                    case OutputMode.PublicDocumentedOnly:
+                        return accessModifier == AccessModifier.Public && hasDocComment;
+                    default:
+                        return true;
+                }
+            }
+
+            #endregion
+
+            #endregion
+        }
+    }
+
+
+}

--- a/DocNet.Core/Parsers/CSharp/CsSourceParser.cs
+++ b/DocNet.Core/Parsers/CSharp/CsSourceParser.cs
@@ -18,7 +18,7 @@ namespace DocNet.Core.Parsers.CSharp
     /// This class is responsible for parsing C# source code into an internal DocNet representation of the namespaces, types,
     /// and doc comments contained in that source code.
     /// </summary>
-    public class CsTextParser : ICsParser
+    public class CsSourceParser : ICsSourceParser
     {
         /// <summary>
         /// Parses C# source code and returns a model of the source code's global namespace, including all child namespaces,
@@ -96,8 +96,6 @@ namespace DocNet.Core.Parsers.CSharp
             walker.Visit(tree.GetRoot());
         }
     }
-
-
 
     internal class CsCommentWalker : CSharpSyntaxWalker
     {
@@ -386,6 +384,8 @@ namespace DocNet.Core.Parsers.CSharp
             return true;
         }
 
+        #region Inclusion Rules
+
         private bool NamespaceShouldBeAdded(NamespaceModel namespaceModel)
         {
             return namespaceModel.Any();
@@ -442,6 +442,8 @@ namespace DocNet.Core.Parsers.CSharp
                     throw new NotImplementedException();
             }
         }
+
+        #endregion
 
         #region Comment Helpers
 

--- a/DocNet.Core/Parsers/CSharp/ICsAssemblyParser.cs
+++ b/DocNet.Core/Parsers/CSharp/ICsAssemblyParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.IO;
+using System.Reflection;
 using DocNet.Core.Models.CSharp;
 
 namespace DocNet.Core.Parsers.CSharp
@@ -7,5 +8,8 @@ namespace DocNet.Core.Parsers.CSharp
     {
         GlobalNamespaceModel GetGlobalNamespace(Assembly assembly, string docFileXml, OutputMode outputMode);
         void ParseIntoNamespace(Assembly assembly, string docFileXml, GlobalNamespaceModel globalNamespace, OutputMode outputMode);
+
+        GlobalNamespaceModel GetGlobalNamespace(Assembly assembly, FileStream docFile, OutputMode outputMode);
+        void ParseIntoNamespace(Assembly assembly, FileStream docFile, GlobalNamespaceModel globalNamespace, OutputMode outputMode);
     }
 }

--- a/DocNet.Core/Parsers/CSharp/ICsAssemblyParser.cs
+++ b/DocNet.Core/Parsers/CSharp/ICsAssemblyParser.cs
@@ -1,0 +1,11 @@
+﻿using System.Reflection;
+using DocNet.Core.Models.CSharp;
+
+namespace DocNet.Core.Parsers.CSharp
+{
+    public interface ICsAssemblyParser
+    {
+        GlobalNamespaceModel GetGlobalNamespace(Assembly assembly, string docFileXml, OutputMode outputMode);
+        void ParseIntoNamespace(Assembly assembly, string docFileXml, GlobalNamespaceModel globalNamespace, OutputMode outputMode);
+    }
+}

--- a/DocNet.Core/Parsers/CSharp/ICsSourceParser.cs
+++ b/DocNet.Core/Parsers/CSharp/ICsSourceParser.cs
@@ -3,7 +3,7 @@ using DocNet.Core.Models.CSharp;
 
 namespace DocNet.Core.Parsers.CSharp
 {
-    public interface ICsParser
+    public interface ICsSourceParser
     {
         /// <summary>
         /// Parses C# source code and returns a model of the source code's global namespace, including all child namespaces,

--- a/Tests/DocNet.Core.Tests/DocFileDeserializationTests.cs
+++ b/Tests/DocNet.Core.Tests/DocFileDeserializationTests.cs
@@ -1,0 +1,11 @@
+﻿
+using NUnit.Framework;
+
+namespace DocNet.Core.Tests
+{
+    [TestFixture]
+    public class DocFileDeserializationTests
+    {
+
+    }
+}

--- a/Tests/DocNet.Core.Tests/DocNet.Core.Tests.csproj
+++ b/Tests/DocNet.Core.Tests/DocNet.Core.Tests.csproj
@@ -72,7 +72,8 @@
     <Compile Include="CommentDeserializationTests.cs" />
     <Compile Include="DocFileDeserializationTests.cs" />
     <Compile Include="Output\Helpers\GetDeclarationTests.cs" />
-    <Compile Include="Parsers\CsParserTests.cs" />
+    <Compile Include="Parsers\CsAssemblyParserTests.cs" />
+    <Compile Include="Parsers\CsSourceParserTests.cs" />
     <Compile Include="Parsers\OnionSolutionParserWrapperTests.cs" />
     <Compile Include="Parsers\ProjectParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests/DocNet.Core.Tests/DocNet.Core.Tests.csproj
+++ b/Tests/DocNet.Core.Tests/DocNet.Core.Tests.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommentDeserializationTests.cs" />
+    <Compile Include="DocFileDeserializationTests.cs" />
     <Compile Include="Output\Helpers\GetDeclarationTests.cs" />
     <Compile Include="Parsers\CsParserTests.cs" />
     <Compile Include="Parsers\OnionSolutionParserWrapperTests.cs" />

--- a/Tests/DocNet.Core.Tests/Parsers/CsAssemblyParserTests.cs
+++ b/Tests/DocNet.Core.Tests/Parsers/CsAssemblyParserTests.cs
@@ -8,7 +8,7 @@ namespace DocNet.Core.Tests.Parsers
     [TestFixture]
     public class CsAssemblyParserTests
     {
-        private const string AssemblyBuildPath = @"..\..\..DummyInputProject\bin\Debug\";
+        private const string AssemblyBuildPath = @"..\..\..\DummyInputProject\bin\Debug\";
         private static readonly string AssemblyPath = Path.Combine(AssemblyBuildPath, "DummyInputProject.dll");
         private static readonly string XmlFilePath = Path.Combine(AssemblyBuildPath, "DummyInputProject.XML");
 

--- a/Tests/DocNet.Core.Tests/Parsers/CsAssemblyParserTests.cs
+++ b/Tests/DocNet.Core.Tests/Parsers/CsAssemblyParserTests.cs
@@ -1,0 +1,24 @@
+﻿using System.IO;
+using System.Reflection;
+using DocNet.Core.Parsers.CSharp;
+using NUnit.Framework;
+
+namespace DocNet.Core.Tests.Parsers
+{
+    [TestFixture]
+    public class CsAssemblyParserTests
+    {
+        private const string AssemblyBuildPath = @"..\..\..DummyInputProject\bin\Debug\";
+        private static readonly string AssemblyPath = Path.Combine(AssemblyBuildPath, "DummyInputProject.dll");
+        private static readonly string XmlFilePath = Path.Combine(AssemblyBuildPath, "DummyInputProject.XML");
+
+        [Test]
+        public void TestHarness()
+        {
+            Assembly assembly = Assembly.LoadFrom(AssemblyPath);
+            var xmlFile = new FileStream(XmlFilePath, FileMode.Open, FileAccess.Read);
+            var parser = new CsAssemblyParser();
+            var globalNamespace = parser.GetGlobalNamespace(assembly, xmlFile, OutputMode.AllElements);
+        }
+    }
+}

--- a/Tests/DocNet.Core.Tests/Parsers/CsParserTests.cs
+++ b/Tests/DocNet.Core.Tests/Parsers/CsParserTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using DocNet.Core.Parsers.CSharp;
 using DocNet.Core.Models.CSharp;
@@ -16,11 +17,33 @@ namespace DocNet.Core.Tests.Parsers
         private static readonly string DuplicateSignatureFile = Path.Combine(TestFileDirectory, "ClassWithDuplicateSignatures.cs");
 
         [Test]
-        public void TestGetNamespaceTreesReturnsAllNamepsaces()
+        public void TestGetGlobalNamespaceThrowsExceptionForNullInput()
+        {
+            var parser = new CsSourceParser();
+            string sourceCode = null;
+            Stream fileStream = null;
+            Assert.Throws<ArgumentNullException>(() => parser.GetGlobalNamespace(sourceCode, OutputMode.AllElements));
+            Assert.Throws<ArgumentNullException>(() => parser.GetGlobalNamespace(fileStream, OutputMode.AllElements));
+        }
+
+        [Test]
+        public void TestParseIntoNamespaceThrowsExceptionForNullInput()
+        {
+            var parser = new CsSourceParser();
+            string sourceCode = null;
+            FileStream fileStream = null;
+            GlobalNamespaceModel globalNamespace = new GlobalNamespaceModel();
+            Assert.Throws<ArgumentNullException>(() => parser.ParseIntoNamespace(sourceCode, globalNamespace, OutputMode.AllElements));
+            Assert.Throws<ArgumentNullException>(() => parser.ParseIntoNamespace(fileStream, globalNamespace, OutputMode.AllElements));
+            Assert.Throws<ArgumentNullException>(() => parser.ParseIntoNamespace("", null, OutputMode.AllElements));
+        }
+
+        [Test]
+        public void TestGetGlobalNamespaceReturnsAllChildNamepsaces()
         {
             // Arrange
             string inputCode = File.ReadAllText(SimpleMultiNamespaceFile);
-            var parser = new CsTextParser();
+            var parser = new CsSourceParser();
 
             // Act
             var globalNamespace = parser.GetGlobalNamespace(inputCode, OutputMode.AllElements);
@@ -34,7 +57,7 @@ namespace DocNet.Core.Tests.Parsers
         {
             // Arrange
             string inputCode = File.ReadAllText(NestedElementFile);
-            var parser = new CsTextParser();
+            var parser = new CsSourceParser();
             
             var expectedGlobalNamespace = new GlobalNamespaceModel();
             
@@ -120,7 +143,7 @@ namespace DocNet.Core.Tests.Parsers
         {
             // Arrange
             string inputCode = File.ReadAllText(PartialElementFile);
-            var parser = new CsTextParser();
+            var parser = new CsSourceParser();
 
             // Act
             var returnedNamespace = parser.GetGlobalNamespace(inputCode, OutputMode.AllElements);
@@ -155,7 +178,7 @@ namespace DocNet.Core.Tests.Parsers
         {
             // Arrange
             string inputCode = File.ReadAllText(DuplicateSignatureFile);
-            var parser = new CsTextParser();
+            var parser = new CsSourceParser();
 
             // Act
             var returnedNamespace = parser.GetGlobalNamespace(inputCode, OutputMode.AllElements);

--- a/Tests/DocNet.Core.Tests/Parsers/CsSourceParserTests.cs
+++ b/Tests/DocNet.Core.Tests/Parsers/CsSourceParserTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace DocNet.Core.Tests.Parsers
 {
     [TestFixture]
-    public class CsParserTests
+    public class CsSourceParserTests
     {
         private const string TestFileDirectory = @"..\..\..\TestData";
         private static readonly string SimpleMultiNamespaceFile = Path.Combine(TestFileDirectory, "SimpleMultiNamespaceFile.cs");

--- a/Tests/DummyInputProject/ExampleClass.cs
+++ b/Tests/DummyInputProject/ExampleClass.cs
@@ -70,10 +70,9 @@ namespace DummyInputProject
     /// For multiple lines of code, the &lt;code&gt; tag is used.
     ///     <code>
     ///     Example code line 1;
-  ///Example code line 2;
+    ///Example code line 2;
     ///     </code>
     ///</example>
-	///BLADAALADLADLALDSKFkjsdz;ganktgjdsjlag;alisj;lhigjaskdljg;alsjgewijgjsdkglkjsddkgljklj
     /// <seealso cref="ExampleClass.ExampleGetter"/>
     public class ExampleClass
     {

--- a/Tests/DummyInputProject/ExampleClass.cs
+++ b/Tests/DummyInputProject/ExampleClass.cs
@@ -150,7 +150,7 @@ namespace DummyInputProject
         ///     An instance of type <typeparamref name="T"/>
         ///     The &lt;typeparamref&gt; tag is used to reference type parameters by name.
         /// </returns>
-        public T GenericFunction<T>() where T : ExampleClass
+        public T GenericFunction<T>() where T : ExampleClass, new()
         {
             return null;
         }


### PR DESCRIPTION
Added option to specify assembly/xml pair as input.
Use the -s flag to specify source files (as before).
Use the -a flag to specify assembly/xml file pairs:
assemblyFile1.dll=xmlFile1.xml,assemblyFile2.dll=xmlFile2.xml
Split the Execute method in DocNetController in two so
that it can handle the two kinds of parsing.
